### PR TITLE
Update docker-compose to specify build context and platforms

### DIFF
--- a/src/web_service/docker-compose.yml
+++ b/src/web_service/docker-compose.yml
@@ -1,6 +1,11 @@
 services:
   chess-scoresheet-digitalization:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile
+      platforms:
+        - linux/arm64
+        - linux/amd64
     command: sh -c "uvicorn main:app --reload --port=8000 --host=0.0.0.0"
     image: ${DOCKER_USERNAME}/chess-scoresheet-digitalization:${DOCKER_IMAGE_VERSION}
     ports:


### PR DESCRIPTION
The build configuration now explicitly defines the context, Dockerfile, and target platforms (linux/arm64 and linux/amd64). This ensures compatibility across different architectures and improves build clarity.